### PR TITLE
Reduce first load JS on blog posts by 53%

### DIFF
--- a/components/Code.tsx
+++ b/components/Code.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import darcula from 'react-syntax-highlighter/dist/cjs/styles/prism/darcula';
-import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { PrismLight, PrismAsyncLight } from "react-syntax-highlighter"
+
+const SyntaxHighlighter =
+  typeof window === "undefined" ? PrismLight : PrismAsyncLight
 
 export default class Code extends React.PureComponent<{
   language: string;

--- a/components/Code.tsx
+++ b/components/Code.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import darcula from 'react-syntax-highlighter/dist/cjs/styles/prism/darcula';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 export default class Code extends React.PureComponent<{
   language: string;

--- a/components/Code.tsx
+++ b/components/Code.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { darcula } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import darcula from 'react-syntax-highlighter/dist/cjs/styles/prism/darcula';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 
 export default class Code extends React.PureComponent<{

--- a/md/blog/the-ultimate-tech-stack.md
+++ b/md/blog/the-ultimate-tech-stack.md
@@ -174,7 +174,7 @@ Head to the GitHub repo to get started: [https://github.com/colinhacks/devii](ht
 
 To jump straight into the code, clone the repo and start the development server like so:
 
-```sh
+```bash
 git clone git@github.com:colinhacks/devii.git mysite
 cd mysite
 yarn


### PR DESCRIPTION
There are a couple small changes you can make to the react-syntax-highlighter imports that massively improve the bundle size for blog post pages.  There are some minor tradeoffs, but I think this is a better default behavior.

I wrote [a blog post about this](https://ahurle.dev/blog/overengineering-a-nextjs-dev-blog?utm_source=github#trimming-the-fat) with screenshots of the PageSpeed score impact on my repo along with some other changes (69 -> 98).  This is basically a backport of some commits in [this PR](https://github.com/fracture91/ahurle-dev/pull/1).  The bundlewatch output from reverting one of the commits [can be seen here](https://github.com/fracture91/ahurle-dev/pull/2).